### PR TITLE
CHORIA_TOKEN should be token rather than json

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ plugin.choria.security.request_signer.token_environment = CHORIA_TOKEN
 You'll need to set the token in your shell:
 
 ```
-export CHORIA_TOKEN=$(curl -s --request POST -d '{"username":"puppetadmin", "password":"secret"}' -H "Content-type: application/json" https://localhost:8080/choria/v1/login)
+export CHORIA_TOKEN=$(curl -s --request POST -d '{"username":"puppetadmin", "password":"secret"}' -H "Content-type: application/json" https://localhost:8080/choria/v1/login | jq -r .token)
 ```
 
 At this point you can use `mco` cli as always, requests will be sent to the signer for signing, users will not need their own certificates or use `mco choria request_cert`


### PR DESCRIPTION
As the example stands the result is.

```
$ export CHORIA_TOKEN=$(curl -s --request POST -d '{"username":"user", "password":"pass"}' -H "Content-type: application/json" -k http://localhost:8080/choria/v1/login )
$ choria ping
WARN[0000] Puppet security system requesting legacy TLS support  component=security ssl=puppet
FATA[0000] Could not run Choria: could not perform request: could not connect: could not create connector: could not parse JWT: illegal base64 data at input byte 0
```

pulling out just the token string.

```
$ export CHORIA_TOKEN=$(curl -s --request POST -d '{"username":"user", "password":"pass"}' -H "Content-type: application/json" -k http://localhost:8080/choria/v1/login | jq -r .token )
$ choria ping -d
...
INFO[0000] Setting JWT token and unique reply queues based on JWT for "up=user"  component=client connection=user-efbebc7607314ffd93c3$
f4d4d3b5c5b-publisher
DEBU[0000] Setting anonymous TLS for NATS connection     component=client connection=user-efbebc7607314ffd93c3df4d4d3b5c5b-publisher
INFO[0000] Attempting to connect to: nats://ch-broke-client.cern.ch:4222  component=client connection=user-efbebc7607314ffd93c3df4d4d3b5c5$
-publisher
INFO[0000] Setting JWT token and unique reply queues based on JWT for "up=user"  component=client connection=user-efbebc7607314ffd93c3$
f4d4d3b5c5b-receiver0
DEBU[0000] Setting anonymous TLS for NATS connection     component=client connection=user-efbebc7607314ffd93c3df4d4d3b5c5b-receiver0
...