### PR TITLE
(misc) Use go 1.16 consistantly in build and build on Podman as well

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ end
 desc "Builds packages"
 task :build do
   version = ENV["VERSION"] || "0.0.0"
+  docker_socket = ENV["DOCKER_SOCKET"] || "/var/run/docker.sock"
   sha = `git rev-parse --short HEAD`.chomp
   build = ENV["BUILD"] || "foss"
   packages = (ENV["PACKAGES"] || "").split(",")
@@ -30,7 +31,8 @@ task :build do
       builder = "choria/packager:el7-go1.16"
     end
 
-    sh 'docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:%s -e SOURCE_DIR=%s -e ARTIFACTS=%s -e SHA1="%s" -e BUILD="%s" -e VERSION="%s" -e PACKAGE=%s %s' % [
+    sh 'docker run --rm -v %s:/var/run/docker.sock -v `pwd`:%s -e SOURCE_DIR=%s -e ARTIFACTS=%s -e SHA1="%s" -e BUILD="%s" -e VERSION="%s" -e PACKAGE=%s %s' % [
+      docker_socket,
       source,
       source,
       source,

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ task :build_binaries do
 
   source = "/go/src/github.com/choria-io/aaasvc"
 
-  sh 'docker run --rm  -v `pwd`:%s -e SOURCE_DIR=%s -e ARTIFACTS=%s -e SHA1="%s" -e BUILD="%s" -e VERSION="%s" -e BINARY_ONLY=1 choria/packager:el7-go13' % [
+  sh 'docker run --rm  -v `pwd`:%s -e SOURCE_DIR=%s -e ARTIFACTS=%s -e SHA1="%s" -e BUILD="%s" -e VERSION="%s" -e BINARY_ONLY=1 choria/packager:el7-go1.16' % [
     source,
     source,
     source,

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ task :build do
       builder = "choria/packager:el7-go1.16"
     end
 
-    sh 'docker run --rm -v %s:/var/run/docker.sock -v `pwd`:%s -e SOURCE_DIR=%s -e ARTIFACTS=%s -e SHA1="%s" -e BUILD="%s" -e VERSION="%s" -e PACKAGE=%s %s' % [
+    sh 'docker run --rm -v %s:/var/run/docker.sock -v `pwd`:%s:Z -e SOURCE_DIR=%s -e ARTIFACTS=%s -e SHA1="%s" -e BUILD="%s" -e VERSION="%s" -e PACKAGE=%s %s' % [
       docker_socket,
       source,
       source,
@@ -53,7 +53,7 @@ task :build_binaries do
 
   source = "/go/src/github.com/choria-io/aaasvc"
 
-  sh 'docker run --rm  -v `pwd`:%s -e SOURCE_DIR=%s -e ARTIFACTS=%s -e SHA1="%s" -e BUILD="%s" -e VERSION="%s" -e BINARY_ONLY=1 choria/packager:el7-go1.16' % [
+  sh 'docker run --rm  -v `pwd`:%s:Z -e SOURCE_DIR=%s -e ARTIFACTS=%s -e SHA1="%s" -e BUILD="%s" -e VERSION="%s" -e BINARY_ONLY=1 choria/packager:el7-go1.16' % [
     source,
     source,
     source,


### PR DESCRIPTION
* Use go 1.16 on build_binaries method.
* Set selinux context of bind mounted source.
* Support environment variable `DOCKER_SOCKET` so that it can be set to `${XDG_RUNTIME_DIR}/podman/podman.sock` for 
   the podman case.