### PR TITLE
(#114) Require a signature in signing requests

### DIFF
--- a/api/gen/models/sign_request.go
+++ b/api/gen/models/sign_request.go
@@ -17,9 +17,12 @@ import (
 // swagger:model SignRequest
 type SignRequest struct {
 
-	// base64 encoded choria:request:1 message to sign
+	// base64 encoded Choria protocol.Request message to sign
 	// Format: byte
 	Request strfmt.Base64 `json:"request,omitempty"`
+
+	// A signature, hex encoded, made using the private key matching the public key in the token
+	Signature string `json:"signature,omitempty"`
 
 	// The JWT token identifying the user, obtained from /login
 	Token string `json:"token,omitempty"`

--- a/api/gen/models/sign_response.go
+++ b/api/gen/models/sign_response.go
@@ -20,9 +20,12 @@ type SignResponse struct {
 	// An error message indicating why signing failed
 	Error string `json:"error,omitempty"`
 
-	// base64 encoded choria:secure:request:1 signed message
+	// base64 encoded protocol.SecureRequest signed message
 	// Format: byte
 	SecureRequest strfmt.Base64 `json:"secure_request,omitempty"`
+
+	// Details to assist tests
+	Detail string `json:"-"`
 }
 
 // Validate validates this sign response

--- a/api/gen/restapi/embedded_spec.go
+++ b/api/gen/restapi/embedded_spec.go
@@ -136,9 +136,13 @@ func init() {
       "type": "object",
       "properties": {
         "request": {
-          "description": "base64 encoded choria:request:1 message to sign",
+          "description": "base64 encoded Choria protocol.Request message to sign",
           "type": "string",
           "format": "byte"
+        },
+        "signature": {
+          "description": "A signature, hex encoded, made using the private key matching the public key in the token",
+          "type": "string"
         },
         "token": {
           "description": "The JWT token identifying the user, obtained from /login",
@@ -154,7 +158,7 @@ func init() {
           "type": "string"
         },
         "secure_request": {
-          "description": "base64 encoded choria:secure:request:1 signed message",
+          "description": "base64 encoded protocol.SecureRequest signed message",
           "type": "string",
           "format": "byte"
         }
@@ -281,9 +285,13 @@ func init() {
       "type": "object",
       "properties": {
         "request": {
-          "description": "base64 encoded choria:request:1 message to sign",
+          "description": "base64 encoded Choria protocol.Request message to sign",
           "type": "string",
           "format": "byte"
+        },
+        "signature": {
+          "description": "A signature, hex encoded, made using the private key matching the public key in the token",
+          "type": "string"
         },
         "token": {
           "description": "The JWT token identifying the user, obtained from /login",
@@ -299,7 +307,7 @@ func init() {
           "type": "string"
         },
         "secure_request": {
-          "description": "base64 encoded choria:secure:request:1 signed message",
+          "description": "base64 encoded protocol.SecureRequest signed message",
           "type": "string",
           "format": "byte"
         }

--- a/api/gen/restapi/operations/choria_central_signing_service_api.go
+++ b/api/gen/restapi/operations/choria_central_signing_service_api.go
@@ -105,7 +105,7 @@ type ChoriaCentralSigningServiceAPI struct {
 	CommandLineOptionsGroups []swag.CommandLineOptionsGroup
 
 	// User defined logger function.
-	Logger func(string, ...any)
+	Logger func(string, ...interface{})
 }
 
 // UseRedoc for documentation at /docs

--- a/api/gen/restapi/operations/post_login.go
+++ b/api/gen/restapi/operations/post_login.go
@@ -44,7 +44,7 @@ type PostLogin struct {
 func (o *PostLogin) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostLoginParams()
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params

--- a/api/gen/restapi/operations/post_login_parameters.go
+++ b/api/gen/restapi/operations/post_login_parameters.go
@@ -6,7 +6,6 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -66,7 +65,7 @@ func (o *PostLoginParams) BindRequest(r *http.Request, route *middleware.Matched
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/api/gen/restapi/operations/post_sign.go
+++ b/api/gen/restapi/operations/post_sign.go
@@ -44,7 +44,7 @@ type PostSign struct {
 func (o *PostSign) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostSignParams()
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params

--- a/api/gen/restapi/operations/post_sign_parameters.go
+++ b/api/gen/restapi/operations/post_sign_parameters.go
@@ -6,7 +6,6 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -66,7 +65,7 @@ func (o *PostSignParams) BindRequest(r *http.Request, route *middleware.MatchedR
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/api/gen/restapi/server.go
+++ b/api/gen/restapi/server.go
@@ -105,7 +105,7 @@ type Server struct {
 }
 
 // Logf logs message either via defined user logger or via system one if no user logger is defined.
-func (s *Server) Logf(f string, args ...any) {
+func (s *Server) Logf(f string, args ...interface{}) {
 	if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 	} else {
@@ -115,7 +115,7 @@ func (s *Server) Logf(f string, args ...any) {
 
 // Fatalf logs message either via defined user logger or via system one if no user logger is defined.
 // Exits with non-zero status after printing
-func (s *Server) Fatalf(f string, args ...any) {
+func (s *Server) Fatalf(f string, args ...interface{}) {
 	if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 		os.Exit(1)
@@ -304,10 +304,6 @@ func (s *Server) Serve() (err error) {
 			// this happens with a wrong custom TLS configurator
 			s.Fatalf("no certificate was configured for TLS")
 		}
-
-		// must have at least one certificate or panics
-		//lint:ignore SA1019 generated code
-		httpsServer.TLSConfig.BuildNameToCertificate()
 
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -96,10 +96,14 @@ definitions:
         type: "string"
         description: "The JWT token identifying the user, obtained from /login"
 
+      signature:
+        type: "string"
+        description: "A signature, hex encoded, made using the private key matching the public key in the token"
+
       request:
         type: "string"
         format: "byte"
-        description: "base64 encoded choria:request:1 message to sign"
+        description: "base64 encoded Choria protocol.Request message to sign"
 
   SignResponse:
     type: "object"
@@ -107,7 +111,7 @@ definitions:
       secure_request:
         type: "string"
         format: "byte"
-        description: "base64 encoded choria:secure:request:1 signed message"
+        description: "base64 encoded protocol.SecureRequest signed message"
 
       error:
         type: "string"

--- a/service/agent.go
+++ b/service/agent.go
@@ -11,8 +11,9 @@ import (
 )
 
 type SignRPCRequest struct {
-	Request string `json:"request"`
-	Token   string `json:"token"`
+	Request   string `json:"request"`
+	Token     string `json:"token"`
+	Signature string `json:"signature"`
 }
 
 type SignRPCResponse struct {
@@ -47,7 +48,7 @@ func signAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, a
 	output := &SignRPCResponse{}
 	reply.Data = output
 
-	allowed, signed, err := signers.SignRequest([]byte(input.Request), input.Token)
+	allowed, signed, err := signers.SignRequest([]byte(input.Request), input.Token, input.Signature)
 	switch {
 	case !allowed && err == nil:
 		reply.Statusmsg = "Request Denied"

--- a/signers/signers.go
+++ b/signers/signers.go
@@ -21,7 +21,7 @@ type Signer interface {
 	Sign(req *models.SignRequest) *models.SignResponse
 
 	// SignRequest signs req based on token
-	SignRequest(req []byte, token string) (bool, []byte, error)
+	SignRequest(req []byte, token string, signature string) (bool, []byte, error)
 
 	// SetAuditors add auditors to be called after signing actions
 	SetAuditors(...auditors.Auditor)
@@ -39,7 +39,7 @@ func SetSigner(s Signer) {
 }
 
 // SignRequest signs a request based on a token using the configured signer
-func SignRequest(req []byte, token string) (bool, []byte, error) {
+func SignRequest(req []byte, token string, signature string) (bool, []byte, error) {
 	mu.Lock()
 	s := signer
 	mu.Unlock()
@@ -48,7 +48,7 @@ func SignRequest(req []byte, token string) (bool, []byte, error) {
 		return false, nil, fmt.Errorf("no signer configured")
 	}
 
-	return s.SignRequest(req, token)
+	return s.SignRequest(req, token, signature)
 }
 
 // SignHandler is a HTTP middleware handler for signing messages using the signer set by SetSigner


### PR DESCRIPTION
This requires that signing requests are signed using the private key matching the public key in the supplied token, effectively moving aware from bearer tokens.

Bearer token behaviour can be optionally enabled

Signed-off-by: R.I.Pienaar <rip@devco.net>